### PR TITLE
Fix log_level default

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -20,7 +20,7 @@ class MainConfig:
     save_epochs: Optional[int] = 1
     sample_steps: Optional[int] = None
     sample_epochs: Optional[int] = 1
-    log_level: str = "loggging.WARNING"
+    log_level: str = "logging.WARNING"
     wandb: Optional[str] = None
 
 @dataclass


### PR DESCRIPTION
## Summary
- fix typo in log_level default in config

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683fb0e9f2ec8320833021f99031643c